### PR TITLE
fix: handle async middleware errors and validate OAuth grant ownership

### DIFF
--- a/src/Router/ApiRoutes/Middlewares/AuthorizationMiddleware.ts
+++ b/src/Router/ApiRoutes/Middlewares/AuthorizationMiddleware.ts
@@ -17,16 +17,20 @@ const INVALID_OR_EXPIRED_TOKEN: ApiErrTemplate = {
 };
 
 export default async function handleApiAuthorization(req: Express.Request, res: Express.Response, next: Express.NextFunction): Promise<void> {
-  const accessToken = Tokens.extractBearerToken(req);
-  if (accessToken == null || !Tokens.checkTokenSyntax(accessToken)) {
-    return next(ApiError.create(MISSING_OR_INVALID_TOKEN_SYNTAX));
-  }
+  try {
+    const accessToken = Tokens.extractBearerToken(req);
+    if (accessToken == null || !Tokens.checkTokenSyntax(accessToken)) {
+      return next(ApiError.create(MISSING_OR_INVALID_TOKEN_SYNTAX));
+    }
 
-  const grant = await db.getActiveGrantForAccessToken(accessToken);
-  if (grant == null) {
-    return next(ApiError.create(INVALID_OR_EXPIRED_TOKEN));
-  }
+    const grant = await db.getActiveGrantForAccessToken(accessToken);
+    if (grant == null) {
+      return next(ApiError.create(INVALID_OR_EXPIRED_TOKEN));
+    }
 
-  res.locals.grant = grant;
-  next();
+    res.locals.grant = grant;
+    next();
+  } catch (err) {
+    next(err);
+  }
 }

--- a/src/Router/OAuthRouter.ts
+++ b/src/Router/OAuthRouter.ts
@@ -126,6 +126,7 @@ export default class OAuthRouter {
               .then((grant) => {
                 if (!grant) return next(ApiError.create(ApiErrs.NOT_FOUND));
                 if (grant.result != null || grant.issuedDuringLast24Hours != true) return next(new ApiError(400, 'Grant already fulfilled or expired', false, {grantID: grant.id}));
+                if (grant.mcAccountId != req.session?.mcProfile?.id || grant.appId != clientID) return next(ApiError.create(ApiErrs.FORBIDDEN));
 
                 db.getApp(clientID)
                     .then(async (app): Promise<void> => {

--- a/src/Router/OAuthRouter.ts
+++ b/src/Router/OAuthRouter.ts
@@ -125,8 +125,8 @@ export default class OAuthRouter {
           db.getGrant(grantID)
               .then((grant) => {
                 if (!grant) return next(ApiError.create(ApiErrs.NOT_FOUND));
+                if (grant.mcAccountId != req.session?.mcProfile?.id || grant.appId != clientID) return next(ApiError.create(ApiErrs.NOT_FOUND));
                 if (grant.result != null || grant.issuedDuringLast24Hours != true) return next(new ApiError(400, 'Grant already fulfilled or expired', false, {grantID: grant.id}));
-                if (grant.mcAccountId != req.session?.mcProfile?.id || grant.appId != clientID) return next(ApiError.create(ApiErrs.FORBIDDEN));
 
                 db.getApp(clientID)
                     .then(async (app): Promise<void> => {


### PR DESCRIPTION
This PR fixes two critical production issues: catching unhandled promise rejections in Express 4 API authorization middleware to prevent hanging requests, and adding session account and application validation when fulfilling OAuth authorization grants.